### PR TITLE
SIM-52

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you want to use these assets, read chapter 5.1
 | F4                     | Open the debug console                                          |
 | Left mouse button      | When clicked on a building or vehicle it displays information   |
 | Hold right mouse button| Rotate the camera around                                        |
-| Scroll / (KP) + or -   | Zoom in or out                                                  |
+| Scroll / KP + or -     | Zoom in or out                                                  |
 
 ## 2. Configuration
 
@@ -488,13 +488,15 @@ Depending on the size of the input the game will choose a vehicle to use. You ca
 Layers are fully dynamic depending on the API. Images should be placed at `BASEURL/images/example_icon.png`.
 These images are loaded in the game. You can find the example JSON at paragraph 3.2.
 
+**It is important to use a white icon, since Unity can only colorize white sprites.**
+
 We used the layers for metrics about CPU, Memory and 500 error's.
 
 Layers are managed in the LayerManager class.
 
 You can see the layers in action in the gif at the beginning of this readme.
 
-To disable Team Selection, edit the `config.json`.
+To disable Layers, edit the `config.json`.
 
 ### 4.4 Team selection
 

--- a/innosetup.iss
+++ b/innosetup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "SimTainer"
-#define MyAppVersion "0.3b2"
+#define MyAppVersion "0.4b1"
 #define MyAppPublisher "Wehkamp"
 #define MyAppExeName "SimTainer.exe"
 

--- a/src/Assets/FreeAssets/Prefabs/Bomb.prefab
+++ b/src/Assets/FreeAssets/Prefabs/Bomb.prefab
@@ -29,7 +29,7 @@ Transform:
   m_GameObject: {fileID: 3285111104184262078}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 233, y: 97.042, z: 109.59628}
-  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/src/Assets/Scripts/Components/Navigators/PlaneNavigator.cs
+++ b/src/Assets/Scripts/Components/Navigators/PlaneNavigator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Assets.Scripts.Interfaces;
 using Assets.Scripts.Managers;
 using Assets.Scripts.Utils;
 using UnityEngine;
@@ -147,7 +148,7 @@ namespace Assets.Scripts.Components.Navigators
 					.Instance.GameModel
 					.Neighbourhoods
 					.Single(x => x.Name == hit.collider.gameObject.name.Replace("neighbourhood-", ""))
-					.VisualizedObjects.Count >= MinimumBuildings)
+					.VisualizedObjects.Count(x=>x is IVisualizedBuilding) >= MinimumBuildings)
 				{
 					_fired = true;
 					Instantiate(AssetsManager.Instance.GetPredefinedPrefab(AssetsManager.PrefabType.Bomb),

--- a/src/Assets/Scripts/Managers/CameraController.cs
+++ b/src/Assets/Scripts/Managers/CameraController.cs
@@ -226,8 +226,7 @@ namespace Assets.Scripts.Managers
 
 			// When we scroll our mouse wheel up, zoom in if the camera is not within the minimum distance (set by our zoomMin variable)
 
-			if ((Input.GetAxis("Mouse ScrollWheel") > 0f || Input.GetKey(KeyCode.KeypadPlus) ||
-			     Input.GetKey(KeyCode.Plus)) && size > ZoomMin)
+			if ((Input.GetAxis("Mouse ScrollWheel") > 0f || Input.GetKey(KeyCode.KeypadPlus)) && size > ZoomMin)
 			{
 				size -= ZoomSpeed * Time.deltaTime;
 			}
@@ -235,8 +234,7 @@ namespace Assets.Scripts.Managers
 
 			// When we scroll our mouse wheel down, zoom out if the camera is not outside of the maximum distance (set by our zoomMax variable)
 
-			if ((Input.GetAxis("Mouse ScrollWheel") < 0f || Input.GetKey(KeyCode.KeypadMinus) ||
-			     Input.GetKey(KeyCode.KeypadPlus)) && size < ZoomMax)
+			if ((Input.GetAxis("Mouse ScrollWheel") < 0f || Input.GetKey(KeyCode.KeypadMinus)) && size < ZoomMax)
 			{
 				size += ZoomSpeed * Time.deltaTime;
 			}

--- a/src/Assets/Scripts/Managers/GridManager.cs
+++ b/src/Assets/Scripts/Managers/GridManager.cs
@@ -21,7 +21,7 @@ namespace Assets.Scripts.Managers
 		// Rows are dynamic and changed in the generate city function to match a little with the amount of instances
 		public int Rows { get; private set; } = 50;
 
-		// Cols is a solid 50
+		// Cols is being set by the SettingsManager
 		public int Cols { get; private set; } = 50;
 
 		public const int TileSize = 10;
@@ -67,14 +67,13 @@ namespace Assets.Scripts.Managers
 				x => x.VisualizedObjects.Count
 			).Sum();
 
-			// Make rows based on amount of instances in total divided by 14 so we always have enough space.
-			Rows = instances / 14;
+			Cols = SettingsManager.Instance.Settings.Grid.TilesPerStreet;
 
+			Rows = (instances + gameModel.Neighbourhoods.Count) / Cols * 3;
 			// We always want an uneven number of rows so we can generate a street everywhere
 			if (Rows % 2 == 0)
 				Rows++;
 
-			Cols = SettingsManager.Instance.Settings.Grid.TilesPerStreet;
 			GenerateGrid();
 			VehicleSpawnPoints.Add(new Vector3(0f, 0.2f, 0f), Quaternion.Euler(0, 0f, 0));
 			VehicleSpawnPoints.Add(new Vector3(Cols * TileSize - TileSize, 0.2f, 0f), Quaternion.Euler(0, 0f, 0));

--- a/src/Preset config files/config-free.json
+++ b/src/Preset config files/config-free.json
@@ -11,7 +11,7 @@
     "MinimumBuildings": 2
   },
   "Grid": {
-    "TilesPerStreet": 50
+    "TilesPerStreet": 60
   },
   "Layers": {
     "Enabled": true

--- a/src/Preset config files/config-paid.json
+++ b/src/Preset config files/config-paid.json
@@ -11,7 +11,7 @@
     "MinimumBuildings": 2
   },
   "Grid": {
-    "TilesPerStreet": 50
+    "TilesPerStreet": 60
   },
   "Layers": {
     "Enabled": true

--- a/src/ProjectSettings/ProjectSettings.asset
+++ b/src/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.3 beta 2
+  bundleVersion: 0.4 beta 1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/src/config.json
+++ b/src/config.json
@@ -11,7 +11,7 @@
     "MinimumBuildings": 2
   },
   "Grid": {
-    "TilesPerStreet": 50
+    "TilesPerStreet": 60
   },
   "Layers": {
     "Enabled": true


### PR DESCRIPTION
- Made Active Layer Icon white
- Made bomb smaller
- Removed + and - for zooming. Only use keypad + and -  or scroll for zooming
- Fixed a bug in the plane navigator for selecting a bomb target
- Increased default tiles per street to 60
- Updated version to 0.4b1